### PR TITLE
feat: add RUN_ONCE mode for scheduled parser check and bump all packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+build/
+**/bin/
+**/obj/

--- a/src/NosCoreBot/NosCoreBot.csproj
+++ b/src/NosCoreBot/NosCoreBot.csproj
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.21.2" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.102.1" />
     <PackageReference Include="ConsoleTableExt" Version="3.3.0" />
-    <PackageReference Include="Discord.Net" Version="3.19.1" />
+    <PackageReference Include="Discord.Net" Version="3.20.1" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.6" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
-    <PackageReference Include="NosCore.ParserInputGenerator" Version="3.0.0" />
-    <PackageReference Include="NosCore.Shared" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.11" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.22.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
+    <PackageReference Include="NosCore.ParserInputGenerator" Version="4.1.0" />
+    <PackageReference Include="NosCore.Shared" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NosCoreBot/Program.cs
+++ b/src/NosCoreBot/Program.cs
@@ -26,10 +26,11 @@ namespace NosCoreBot
                 .UseWindowsService()
                 .ConfigureServices((hostContext, services) =>
                 {
+                    var runOnce = Environment.GetEnvironmentVariable("RUN_ONCE") == "true";
                     services.AddSingleton(new DiscordSocketClient(new DiscordSocketConfig
                     {
-                        AlwaysDownloadUsers = true,
-                        GatewayIntents = GatewayIntents.All
+                        AlwaysDownloadUsers = !runOnce,
+                        GatewayIntents = runOnce ? GatewayIntents.Guilds : GatewayIntents.All
                     }))
                         .AddHttpClient()
                         .AddTransient<IExtractor, Extractor>()

--- a/src/NosCoreBot/Services/TimeHandlingService.cs
+++ b/src/NosCoreBot/Services/TimeHandlingService.cs
@@ -159,7 +159,7 @@ namespace NosCoreBot.Services
                 if (_discord.GetChannel(719772084968095775) is SocketTextChannel channel)
                 {
                     var file = new FileInfo(archiveName);
-                    if (file.Length > 8388119)
+                    if ((ulong)file.Length > channel.Guild.MaxUploadLimit)
                     {
                         var send = await channel.SendMessageAsync($"<:altz:699420721088168036><:altz:699420721088168036><:altz:699420721088168036>Parser Too Heavy<:altz:699420721088168036><:altz:699420721088168036><:altz:699420721088168036>\n - Size : {file.Length}");
                     }

--- a/src/NosCoreBot/Worker.cs
+++ b/src/NosCoreBot/Worker.cs
@@ -21,14 +21,16 @@ public class Worker : BackgroundService
     private readonly CommandService _cmservice;
     private readonly CommandHandlingService _chservice;
     private readonly TimeHandlingService _thservice;
+    private readonly IHostApplicationLifetime _lifetime;
 
     public Worker(DiscordSocketClient client, CommandService cmservice, CommandHandlingService chservice,
-        TimeHandlingService thservice)
+        TimeHandlingService thservice, IHostApplicationLifetime lifetime)
     {
         _client = client;
         _cmservice = cmservice;
         _chservice = chservice;
         _thservice = thservice;
+        _lifetime = lifetime;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -36,14 +38,36 @@ public class Worker : BackgroundService
         _client.Log += LogAsync;
         _cmservice.Log += LogAsync;
 
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _client.Ready += () =>
+        {
+            ready.TrySetResult();
+            return Task.CompletedTask;
+        };
+
         // Tokens should be considered secret data, and never hard-coded.
         await _client.LoginAsync(TokenType.Bot, Environment.GetEnvironmentVariable("token"));
         await _client.StartAsync();
+        await ready.Task.WaitAsync(TimeSpan.FromMinutes(2), stoppingToken);
+
+        if (Environment.GetEnvironmentVariable("RUN_ONCE") == "true")
+        {
+            try
+            {
+                await _thservice.UploadInputFilesAsync();
+            }
+            finally
+            {
+                await _client.StopAsync();
+                _lifetime.StopApplication();
+            }
+            return;
+        }
 
         await _chservice.InitializeAsync();
         await _thservice.UploadInputFilesAsync();
 
-        await Task.Delay(-1);
+        await Task.Delay(-1, stoppingToken);
     }
 
     private Task LogAsync(LogMessage log)

--- a/src/NosCoreBot/dockerfile
+++ b/src/NosCoreBot/dockerfile
@@ -1,7 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
-WORKDIR /dotnetapp
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish src/NosCoreBot/NosCoreBot.csproj -c Release -o /app/publish
 
-COPY . /app
-WORKDIR /app/build/net7.0
-
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app/publish .
 ENTRYPOINT ["dotnet", "NosCoreBot.dll"]

--- a/tests/NosCoreBot.Tests/NosCoreBot.Tests.csproj
+++ b/tests/NosCoreBot.Tests/NosCoreBot.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- `RUN_ONCE=true` runs the parser-file check once after Discord Ready then exits - used by the daily ECS Fargate scheduled task (replaces the 24/7 service); a 2-minute ready timeout prevents hung tasks on auth failure
- waits for gateway Ready before checking (the old code raced `StartAsync`) and uses minimal gateway intents in run-once mode
- Discord upload cap now uses `channel.Guild.MaxUploadLimit` instead of the 2021-era hardcoded 8 MB
- dockerfile rebuilt as multi-stage net10.0 from source (was copying a prebuilt net7.0 folder)
- all NuGet packages bumped to latest (Discord.Net 3.20.1, AWSSDK.S3 4.0.102.1, ParserInputGenerator 4.1.0, Shared 6.0.0, Microsoft.* 10.0.11, MSTest 4.3.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a run-once mode for downloading and uploading files before automatic shutdown.
  - Startup now waits for the Discord connection to become ready, with timeout and cancellation support.
  - Archive size limits now follow the configured Discord upload limit.

- **Chores**
  - Updated the application to build and run with .NET 10.
  - Refreshed application and test package versions.
  - Added Docker ignore rules for generated and temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->